### PR TITLE
Fix pagination by checking for presence of "Next" link

### DIFF
--- a/lib/scraper.js
+++ b/lib/scraper.js
@@ -122,14 +122,14 @@ function parseJobList(body, host, excludeSponsored){
     };
   }).get();
 
-  const pageText = $('#searchCount').text();
-  const toNum = pageText.substring(pageText.indexOf('to ')+3, pageText.indexOf(' of'));
-  const ofNum = pageText.substr(pageText.indexOf('of ')+3);
-
-  if(jobTable.children().hasClass('dupetext')){
+  if (jobTable.children().hasClass('dupetext')) {
     // We haven't seen all the results but indeed says the rest are duplicates
     cont = false;
-  }else if(toNum == ofNum){
+  } else if (
+    $('.pagination > *:last-child')
+      .text()
+      .indexOf('Next') === -1
+  ) {
     // We have seen all the results
     cont = false;
   }


### PR DESCRIPTION
My indeed scraper has suddenly stopped detecting the end of a query. Perhaps indeed had a small UI change?

Regardless, this fix checks for presence of "Next" link rather than using the "Page x of y jobs" text.