### PR TITLE
Fix url selector

### DIFF
--- a/lib/scraper.js
+++ b/lib/scraper.js
@@ -99,7 +99,7 @@ function parseJobList(body, host, excludeSponsored){
 
     const jobtitle = job.find('.jobtitle').text().trim();
 
-    const url = 'https://' + host + job.find('.jobtitle').children('a').attr('href');
+    const url = 'https://' + host + job.find('.jobtitle').attr('href');
 
     const summary = job.find('.summary').text().trim();
 


### PR DESCRIPTION
This also seemed to suddenly break at same time as #6.

`.jobtitle` is now the anchor itself.