### PR TITLE
Paging loop fix

### DIFF
--- a/lib/scraper.js
+++ b/lib/scraper.js
@@ -156,6 +156,9 @@ function parseJobList(body, host, excludeSponsored) {
   } else if ($(".pagination > *:last-child").hasClass("np")) {
     // We have seen all the results
     cont = false;
+  } else if (!$(".pagination").length) {
+    // No paging of results
+    cont = false;
   }
 
   return {


### PR DESCRIPTION
This should fix the continuous scraping of additional pages if no paging buttons are found.

I found our company indeed page had no `.pagination` elements at all. Since these appear to be used as a reference for whether another page should be checked or not, the scraper would continue to go thru the same page until `limit` was reached.