### PR TITLE
Correctly encode URI used for scraping

### DIFF
--- a/lib/scraper.js
+++ b/lib/scraper.js
@@ -26,14 +26,14 @@ function Query(qo) {
 Query.prototype.url = function() {
   let q = "https://" + this.host + "/jobs";
   q += "?q=" + this.query;
-  q += "&l=" + this._cityNameForWeb();
+  q += "&l=" + this.city;
   q += "&radius=" + this.radius;
   q += "&explvl=" + this.level;
   q += "&fromage=" + this.maxAge;
   q += "&sort=" + this.sort;
   q += "&jt=" + this.jobType;
   q += "&start=" + this.start;
-  return q;
+  return encodeURI(q);
 };
 Query.prototype._cityNameForWeb = function() {
   return this.city.replace(" ", "+").replace(",", "%2C");

--- a/lib/scraper.js
+++ b/lib/scraper.js
@@ -35,9 +35,6 @@ Query.prototype.url = function() {
   q += "&start=" + this.start;
   return encodeURI(q);
 };
-Query.prototype._cityNameForWeb = function() {
-  return this.city.replace(" ", "+").replace(",", "%2C");
-};
 
 /* Gets all the desired jobs for the city */
 Query.prototype.getJobs = function() {


### PR DESCRIPTION
## Bug description
Scraper fails upon querying certain terms containing umlauts, such as the German job title "Qualitätsmanagement".

## Root cause
The URL of the website to be scraped is constructed without URI encoding.

## Solution
Encode it.

## Testing strategy
This project doesn't seem to have any testing solution set up. I will open an issue for that and reference it here.

I've tested this change manually. Despite best practices, I am issuing the PR despite no automated testing, as I won't have time to add some any time soon, but i suggest to the maintainer to push for the addition of testing, as this tool is highly dependent on a live website and might break without warning or versioning. **It might make sense to not merge this, until testing is in place.**

