### PR TITLE
Use "title" attribute to get full title

### DIFF
--- a/lib/scraper.js
+++ b/lib/scraper.js
@@ -33,6 +33,7 @@ Query.prototype.url = function() {
   q += "&sort=" + this.sort;
   q += "&jt=" + this.jobType;
   q += "&start=" + this.start;
+  q += "&limit=50";
   return encodeURI(q);
 };
 
@@ -50,12 +51,12 @@ Query.prototype.getJobs = function() {
           reject(Error);
         } else if (parsed.continue === true) {
           // If we reach the limit stop looping
-          if (self.limit != 0 && jobs.length > self.limit) {
+          if (self.limit != 0 && jobs.length >= self.limit) {
             while (jobs.length != self.limit) jobs.pop();
             resolve(jobs);
           } else {
             // Continue getting more jobs
-            self.start += 10;
+            self.start += 50;
             getSomeJobs(self, jobs);
           }
         } else {

--- a/lib/scraper.js
+++ b/lib/scraper.js
@@ -95,10 +95,7 @@ function parseJobList(body, host, excludeSponsored) {
     .map((i, e) => {
       const job = $(e);
 
-      const jobtitle = job
-        .find(".jobtitle")
-        .attr("title")
-        .trim();
+      const jobtitle = (job.find(".jobtitle").attr("title") || job.find(".jobtitle").text()).trim();
 
       const url = "https://" + host + job.find(".jobtitle").attr("href");
 

--- a/lib/scraper.js
+++ b/lib/scraper.js
@@ -97,7 +97,7 @@ function parseJobList(body, host, excludeSponsored) {
 
       const jobtitle = job
         .find(".jobtitle")
-        .text()
+        .attr("title")
         .trim();
 
       const url = "https://" + host + job.find(".jobtitle").attr("href");


### PR DESCRIPTION
When a title is too long, indeed clips the title with "..." at the end. To avoid getting clipped titles we use the "title" attribute of the element.