### PR TITLE
Fix Salary Snippet After Indeed UI Update

### DIFF
--- a/lib/scraper.js
+++ b/lib/scraper.js
@@ -124,7 +124,7 @@ function parseJobList(body, host, excludeSponsored) {
         .trim();
 
       const salary = job
-        .find(".salary-snippet")
+        .find(".attribute_snippet")
         .text()
         .trim();
 


### PR DESCRIPTION
Indeed's UI appears to have changed the CSS class on the element that contained the salary. Apparently it's changed to `attribute_snippet` from `salary-snippet`. I'm not sure exactly what the reason for the name change is, as I've only seen it containing salary information.

It'll probably be good to verify that salary fetching is broken everywhere -- wouldn't want this to get merged only to find out it was part of a temporary A/B test Indeed was running. Seems consistent on two of my devices, for whatever that's worth.