### PR TITLE
Fixed scraper not catching title

### DIFF
--- a/lib/scraper.js
+++ b/lib/scraper.js
@@ -96,7 +96,7 @@ function parseJobList(body, host, excludeSponsored) {
       const job = $(e);
 
       const jobtitle = job
-        .find(".jobTitle > span")
+        .find("h2 > a > span")
         .text()
         .trim();
 


### PR DESCRIPTION
The website has changed and the title can be found in the following nested tags
`h2 > a > span`
There is another pull request that suggests "h2 > span" but that doesnt work now.